### PR TITLE
[enh] Remove warning due to missing repository field

### DIFF
--- a/package.json.tpl
+++ b/package.json.tpl
@@ -3,6 +3,7 @@
   "version": "{version}",
   "description": "{name} module for react Highcharts. This package is generated based on {module} v{version}",
   "main": "{file}",
+  "repository": "kirjs/publish-highcharts-modules",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
When installing the generated packages with npm, a warning due to the missing repository field is shown.